### PR TITLE
Add BOSH UAA login and certificate support to the deployment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+.project

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 .project
+.vagrant

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ and then deploy them.
   parameters, as documented below.
 * `username`: *Required.* The username for the BOSH director.
 * `password`: *Required.* The password for the BOSH director.
+* `cert`: *Optional.* The SSL certificate for the BOSH director.
 * `deployment`: *Required.* The name of the deployment.
 
 ### Example
@@ -21,6 +22,7 @@ and then deploy them.
     target: https://bosh.example.com:25555
     username: admin
     password: admin
+    cert: /etc/ssl/certs/boshRootCA.pem
     deployment: staging-deployment-name
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ and then deploy them.
   parameters, as documented below.
 * `username`: *Required.* The username for the BOSH director.
 * `password`: *Required.* The password for the BOSH director.
-* `cert`: *Optional.* The SSL certificate for the BOSH director.
 * `deployment`: *Required.* The name of the deployment.
 
 ### Example
@@ -22,13 +21,13 @@ and then deploy them.
     target: https://bosh.example.com:25555
     username: admin
     password: admin
-    cert: /etc/ssl/certs/boshRootCA.pem
     deployment: staging-deployment-name
 ```
 
 ``` yaml
 - put: staging
   params:
+    cert: cert-task/BOSHRootCA.pem
     manifest: path/to/manifest.yml
     stemcells:
     - path/to/stemcells-*.tgz
@@ -49,6 +48,8 @@ If the manifest does not specify a `director_uuid`, it will be filled in with
 the UUID returned by the targeted director.
 
 #### Parameters
+
+* `cert`: *Optional* Task output path of the SSL certificate for BOSH
 
 * `manifest`: *Required.* Path to a BOSH deployment manifest file.
 

--- a/bin/bdr_out
+++ b/bin/bdr_out
@@ -23,7 +23,7 @@ bosh = BoshDeploymentResource::Bosh.new(
   target,
   source.fetch("username"),
   source.fetch("password"),
-  source.fetch("cert", nil)
+  params.fetch("cert", nil)
 )
 manifest = BoshDeploymentResource::BoshManifest.new(
   File.expand_path(params.fetch("manifest"), working_dir)

--- a/bin/bdr_out
+++ b/bin/bdr_out
@@ -19,10 +19,18 @@ target =
     source.fetch("target")
   end
 
+cert =
+  if cert_file
+    File.read(File.expand_path(cert_file, working_dir)).strip
+  else
+    source.fetch("cert", nil)
+  end
+
 bosh = BoshDeploymentResource::Bosh.new(
   target,
   source.fetch("username"),
   source.fetch("password"),
+  cert
 )
 manifest = BoshDeploymentResource::BoshManifest.new(
   File.expand_path(params.fetch("manifest"), working_dir)

--- a/bin/bdr_out
+++ b/bin/bdr_out
@@ -19,18 +19,11 @@ target =
     source.fetch("target")
   end
 
-cert =
-  if cert_file
-    File.read(File.expand_path(cert_file, working_dir)).strip
-  else
-    source.fetch("cert", nil)
-  end
-
 bosh = BoshDeploymentResource::Bosh.new(
   target,
   source.fetch("username"),
   source.fetch("password"),
-  cert
+  source.fetch("cert", nil)
 )
 manifest = BoshDeploymentResource::BoshManifest.new(
   File.expand_path(params.fetch("manifest"), working_dir)

--- a/bin/bdr_out
+++ b/bin/bdr_out
@@ -19,11 +19,20 @@ target =
     source.fetch("target")
   end
 
+cert_file = params["cert"]
+
+cert =
+  if cert_file
+    File.expand_path(cert_file, working_dir)
+  else
+    nil
+  end
+
 bosh = BoshDeploymentResource::Bosh.new(
   target,
   source.fetch("username"),
   source.fetch("password"),
-  params.fetch("cert", nil)
+  cert
 )
 manifest = BoshDeploymentResource::BoshManifest.new(
   File.expand_path(params.fetch("manifest"), working_dir)

--- a/lib/bosh_deployment_resource/bosh.rb
+++ b/lib/bosh_deployment_resource/bosh.rb
@@ -10,10 +10,14 @@ module BoshDeploymentResource
       @cert = cert
       @command_runner = command_runner
 
-      if @cert && File.exist?(@cert)
+      if cert && File.exist?(cert)
+        # Assumes UAA with SSL cert...
+        run("bosh -n target #{target} --ca-cert #{cert}")
+
+        # TODO: Fix "stty: standard input: Inappropriate ioctl for device" errors
         run(
-          "bosh target #{@target} --ca-cert #{@cert}",
-          { 'BOSH_USER' => @username, 'BOSH_PASSWORD' => @password }
+          "echo -n \"$BOSH_USER\n$BOSH_PASSWORD\" | bosh login 1>/dev/null",
+          { 'BOSH_USER' => username, 'BOSH_PASSWORD' => password }
         )
       end
     end

--- a/lib/bosh_deployment_resource/bosh.rb
+++ b/lib/bosh_deployment_resource/bosh.rb
@@ -3,7 +3,7 @@ require "pty"
 
 module BoshDeploymentResource
   class Bosh
-    def initialize(target, username, password, cert, command_runner=CommandRunner.new)
+    def initialize(target, username, password, cert=nil, command_runner=CommandRunner.new)
       @target = target
       @username = username
       @password = password

--- a/lib/bosh_deployment_resource/bosh.rb
+++ b/lib/bosh_deployment_resource/bosh.rb
@@ -3,11 +3,19 @@ require "pty"
 
 module BoshDeploymentResource
   class Bosh
-    def initialize(target, username, password, command_runner=CommandRunner.new)
+    def initialize(target, username, password, cert, command_runner=CommandRunner.new)
       @target = target
       @username = username
       @password = password
+      @cert = cert
       @command_runner = command_runner
+
+      if @cert && File.exist?(@cert)
+        run(
+          "bosh target #{@target} --ca-cert #{@cert}",
+          { 'BOSH_USER' => @username, 'BOSH_PASSWORD' => @password }
+        )
+      end
     end
 
     def upload_stemcell(path)
@@ -21,7 +29,7 @@ module BoshDeploymentResource
     def deploy(manifest_path)
       bosh("-d #{manifest_path} deploy")
     end
-    
+
     def cleanup
       bosh("cleanup")
     end

--- a/spec/bosh_spec.rb
+++ b/spec/bosh_spec.rb
@@ -37,9 +37,10 @@ describe BoshDeploymentResource::Bosh do
   let(:target) { "http://bosh.example.com" }
   let(:username) { "bosh-userΩΩΩΩ" }
   let(:password) { "bosh-password!#%&#(*" }
+  let(:cert) { "cert/boshCA.pem" }
   let(:command_runner) { instance_double(BoshDeploymentResource::CommandRunner) }
 
-  let(:bosh) { BoshDeploymentResource::Bosh.new(target, username, password, command_runner) }
+  let(:bosh) { BoshDeploymentResource::Bosh.new(target, username, password, cert, command_runner) }
 
   describe ".upload_stemcell" do
     it "runs the command to upload a stemcell" do

--- a/spec/check_spec.rb
+++ b/spec/check_spec.rb
@@ -5,7 +5,7 @@ require "open3"
 
 describe "Check Command" do
   it "outputs and empty json list" do
-    stdout, _, status = Open3.capture3("bdr_check")
+    stdout, _, status = Open3.capture3("bin/bdr_check")
 
     expect(status).to be_success
     expect(JSON.parse(stdout)).to eq([])

--- a/spec/out_spec.rb
+++ b/spec/out_spec.rb
@@ -58,10 +58,10 @@ describe "Out Command" do
         "target" => "http://bosh.example.com",
         "username" => "bosh-username",
         "password" => "bosh-password",
-        "cert" => "cert/boshCA.pem",
         "deployment" => "bosh-deployment",
       },
       "params" => {
+        "cert" => "cert/boshCA.pem",
         "manifest" => "manifest/deployment.yml",
         "stemcells" => [
           "stemcells/*.tgz"
@@ -206,10 +206,10 @@ describe "Out Command" do
               "target" => "http://bosh.example.com",
               "username" => "bosh-user",
               "password" => "bosh-password",
-              "cert" => "cert/boshCA.pem",
               "deployment" => "bosh-deployment",
             },
             "params" => {
+              "cert" => "cert/boshCA.pem",
               "manifest" => "deployment.yml",
               "stemcells" => [],
               "releases" => []

--- a/spec/out_spec.rb
+++ b/spec/out_spec.rb
@@ -58,6 +58,7 @@ describe "Out Command" do
         "target" => "http://bosh.example.com",
         "username" => "bosh-username",
         "password" => "bosh-password",
+        "cert" => "cert/boshCA.pem",
         "deployment" => "bosh-deployment",
       },
       "params" => {
@@ -170,7 +171,7 @@ describe "Out Command" do
         command.run(working_dir, request)
       end
     end
-      
+
     it "does NOT run a bosh cleanup when the cleanup parameter is NOT passed" do
       in_dir do |working_dir|
         add_default_artefacts working_dir
@@ -180,10 +181,10 @@ describe "Out Command" do
         command.run(working_dir, request)
       end
     end
-    
+
     it "runs a bosh cleanup when the cleanup parameter is set to true" do
       request.fetch("params").store("cleanup", true)
-    
+
       in_dir do |working_dir|
         add_default_artefacts working_dir
 
@@ -205,6 +206,7 @@ describe "Out Command" do
               "target" => "http://bosh.example.com",
               "username" => "bosh-user",
               "password" => "bosh-password",
+              "cert" => "cert/boshCA.pem",
               "deployment" => "bosh-deployment",
             },
             "params" => {
@@ -292,8 +294,8 @@ describe "Out Command" do
         end.to raise_error /params must include 'manifest'/
       end
     end
-    
-    it "errors if the cleanup paramater is NOT a boolean value" do
+
+    it "errors if the cleanup parameter is NOT a boolean value" do
       in_dir do |working_dir|
         expect do
           command.run(working_dir, {


### PR DESCRIPTION
This is a temporarily patched Concourse core Bosh Deployment Resource Docker image that supports BOSH UAA login and SSL certificates
